### PR TITLE
Updated X-UA-Compatible meta-tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta http-equiv="refresh" content="0; url=http://www.wunderlist.com">
     <title>wunderlist.github.io</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">


### PR DESCRIPTION
Chrome Frame was discontinued in 2014, so no need for outdated meta-tag.

https://blog.chromium.org/2013/06/retiring-chrome-frame.html